### PR TITLE
Only set up an Alias with a newer BuildNumber, not blindly

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/buildaliassetter/Alias.java
+++ b/src/main/java/org/jenkinsci/plugins/buildaliassetter/Alias.java
@@ -57,6 +57,10 @@ import hudson.model.Run;
         return name;
     }
 
+    public int getBuildNumber() {
+        return buildNumber;
+    }
+    
     @Override
     public String getDisplayName() {
 

--- a/src/main/java/org/jenkinsci/plugins/buildaliassetter/PermalinkStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/buildaliassetter/PermalinkStorage.java
@@ -66,7 +66,8 @@ public class PermalinkStorage extends JobProperty<Job<?,?>> implements Permalink
             final int buildNumber = entry.getKey();
             for (final String alias: entry.getValue()) {
 
-                links.put(alias, new Alias(buildNumber, alias));
+                if(!links.containsKey(alias) || (links.containsKey(alias) && ((Alias)(links.get(alias))).getBuildNumber() < buildNumber ))
+                    links.put(alias, new Alias(buildNumber, alias));
             }
         }
 


### PR DESCRIPTION
This means a newer build will always take precedence over an older build, if they share an alias, rather than the order being somewhat random based on the underlying map objects' storage order.

[JENKINS-30426](https://issues.jenkins-ci.org/browse/JENKINS-30426)
